### PR TITLE
TesClient initialization extended with optional headers

### DIFF
--- a/pydantictes/api.py
+++ b/pydantictes/api.py
@@ -28,9 +28,13 @@ def raise_for_status(response):
 
 
 class TesClient:
-    def __init__(self, url: str):
+    def __init__(self, url: str, headers: dict = None):
         self._url = url
         self._headers = {"Content-Type": "application/json"}
+
+        # Merge optional headers
+        if headers:
+            self._headers.update(headers)
 
     def create_task(self, task: TesTask) -> TesCreateTaskResponse:
         url = self._build_url("tasks")


### PR DESCRIPTION
This PR enables simple authorisation using BasicAuth as well as more complex OAuth2 token authorisation considering the client is able to obtain and refresh the tokens. 

This PR is connected to the development of [Tesp-api](https://github.com/CESNET/tesp-api) and the functionality to configure the BasicAuth in Galaxy and use it in PulsarTesJobRunner is impleneted in this [Pulsar fork](https://github.com/BorisYourich/pulsar)

The client using pydantic-tes only needs to specify the additional authorisation header when initialising client :
```
if auth_type == "basic":
        basic_auth = destination_params.get("basic_auth", {})
        username = basic_auth.get("username")
        password = basic_auth.get("password")
        if username and password:
            auth_string = f"{username}:{password}"
            auth_base64 = base64.b64encode(auth_string.encode()).decode()
            headers["Authorization"] = f"Basic {auth_base64}"

    return TesClient(url=tes_url, headers=headers)
```