### PR TITLE
Drop deprecated pydantic V1 syntax, require pydantic>=2.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.14']
+        python-version: ['3.10', '3.14']
         server-target: ["DEPLOY", "https://csc-tesk-noauth.rahtiapp.fi"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.14']
+        python-version: ['3.10', '3.14']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go 1.x

--- a/pydantictes/api.py
+++ b/pydantictes/api.py
@@ -40,7 +40,7 @@ class TesClient:
 
     def create_task(self, task: TesTask) -> TesCreateTaskResponse:
         url = self._build_url("tasks")
-        response = requests.post(url, data=task.json(), headers=self._headers)
+        response = requests.post(url, data=task.model_dump_json(), headers=self._headers)
         raise_for_status(response)
         return TesCreateTaskResponse(**response.json())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydantic
+pydantic>=2
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude =
     .eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ version = attr: pydantictes.__version__
 # TODO: Make requests conditional
 include_package_data = True
 install_requires =
-    pydantic
+    pydantic>=2
     requests
     typing-extensions
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,6 @@ classifiers =
         License :: OSI Approved :: MIT License
         Operating System :: OS Independent
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.8
-        Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
         Programming Language :: Python :: 3.11
         Programming Language :: Python :: 3.12
@@ -53,7 +51,7 @@ install_requires =
     requests
     typing-extensions
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.extras_require]
 testing =

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     mypy: pytest
     test: pytest
     test: -rrequirements.txt
-    lintreadme: readme
+    lintreadme: twine
 skip_install =
     lint,lintreadme: True
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ python =
 commands =
     test: pytest -s {[tox]test_dir} {posargs}
     lint: flake8 {[tox]source_dir} {[tox]test_dir} {posargs}
-    lintreadme: make lint-readme
+    lintreadme: python -m build
+    lintreadme: twine check dist/*
     mypy: mypy {[tox]source_dir} {[tox]test_dir} {posargs}
 deps =
     lint: flake8-import-order
@@ -28,10 +29,11 @@ deps =
     test: pytest
     test: -rrequirements.txt
     lintreadme: twine
+    lintreadme: build
 skip_install =
     lint,lintreadme: True
-allowlist_externals =
-    lintreadme: make
+changedir =
+    lintreadme: {toxinidir}
 passenv =
     FUNNEL_*
     GO*

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 # TODO: implement doc linting
 [tox]
-envlist = py{38,39,310,311,312,313,314}-lint, py38-lintreadme, py{38,39,310,311,312,313,314}-mypy, py{38,39,310,311,312,313,314}-test
+envlist = py{310,311,312,313,314}-lint, py310-lintreadme, py{310,311,312,313,314}-mypy, py{310,311,312,313,314}-test
 source_dir = pydantictes
 test_dir = test
 
 [gh-actions]
 python =
-    3.8: py38-mypy, py38-lint, py38-test, py38-lintreadme
-    3.9: py39-mypy, py39-lint, py39-test
-    3.10: py310-mypy, py310-lint, py310-test
+    3.10: py310-mypy, py310-lint, py310-test, py310-lintreadme
     3.11: py311-mypy, py311-lint, py311-test
     3.12: py312-mypy, py312-lint, py312-test
     3.13: py313-mypy, py313-lint, py313-test


### PR DESCRIPTION
Pydantic V2 is already de-facto required — models use V2-only features such as json_schema_extra in Field(). Pin the dependency accordingly and replace the last remaining V1 method call (.json() -> .model_dump_json()).